### PR TITLE
Traefik master removed dumpcerts.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update \
   util-linux \
   bash \
   tini \
-  && curl https://raw.githubusercontent.com/containous/traefik/master/contrib/scripts/dumpcerts.sh -o /dumpcerts.sh \
+  && curl https://github.com/containous/traefik/raw/v1.7/contrib/scripts/dumpcerts.sh -o /dumpcerts.sh \
   && chmod +x /dumpcerts.sh \
   && mkdir -p /dump-target /ssl-share
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update \
   util-linux \
   bash \
   tini \
-  && curl https://github.com/containous/traefik/raw/v1.7/contrib/scripts/dumpcerts.sh -o /dumpcerts.sh \
+  && curl https://raw.githubusercontent.com/containous/traefik/v1.7/contrib/scripts/dumpcerts.sh -o /dumpcerts.sh \
   && chmod +x /dumpcerts.sh \
   && mkdir -p /dump-target /ssl-share
 


### PR DESCRIPTION
Traefik master removed dumpcerts.sh so pull it from v1.7, the latest version including this file