### PR TITLE
Refresh certs on the first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ certdumper:
   depends_on:
     # Here should be the name of your traefik service
     - name-of-traefik-service-goes-here
+    # Here should be mailcow services that will be restarted after cert change
+    - postfix-mailcow
+    - dovecot-mailcow
+    - nginx-mailcow
   restart: always
   volumes:
     # This volume mounts the traefik root folder into the container for access

--- a/watcher.sh
+++ b/watcher.sh
@@ -3,7 +3,6 @@
 sleep 10s
 
 while true; do
-    inotifywait -e modify /traefik/acme.json
     bash /dumpcerts.sh /traefik/acme.json /dump-target
     cp "/dump-target/private/${DOMAIN}.key" /ssl-share/key.pem
     cp "/dump-target/certs/${DOMAIN}.crt" /ssl-share/cert.pem
@@ -12,4 +11,5 @@ while true; do
     dovecot_c=$(docker ps -qaf name=dovecot-mailcow)
     nginx_c=$(docker ps -qaf name=nginx-mailcow)
     docker restart ${postfix_c} ${dovecot_c} ${nginx_c}
+    inotifywait -e modify /traefik/acme.json
 done


### PR DESCRIPTION
Nice project, works great!

I'd like to propose to improve the very first run experience by moving `iwatch` to the end of the loop; this way once you add this adapter and boot it up, it will go and immediately copy certs from traefik, instead of waiting for them to be changed.

I also added dependency on the services that will be restarted when certificate changes, just so that this adapter doesn't try to kill services that haven't started yet.